### PR TITLE
“Siegman” instead of “Seigman”

### DIFF
--- a/index.html
+++ b/index.html
@@ -1014,7 +1014,7 @@ border-collapse: collapse;
      <dt>This version:
      <dd><a class="u-url" href="http://dauwhe.github.io/epub-zero/">http://dauwhe.github.io/epub-zero/</a>
      <dt class="editor">Editors:
-     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:tseigman@wiley.com">Tzviya Seigman</a> (<span class="p-org org">Wiley</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:tsiegman@wiley.com">Tzviya Siegman</a> (<span class="p-org org">Wiley</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:dauwhe@gmail.com">Dave Cramer</a> (<span class="p-org org">Hachette Livre</span>)
     </dl>
    </div>


### PR DESCRIPTION
Unless Tzviya goes by multiple names, it sounds like there was a typo in both her full name and email address.
